### PR TITLE
slicing infrastructure + bug fixes

### DIFF
--- a/rle_array/_algorithms.py
+++ b/rle_array/_algorithms.py
@@ -214,7 +214,7 @@ def find_slice(
 
     start, stop, step = s_norm.start, s_norm.stop, s_norm.step
     invert = False
-    if s_norm.step < 0:
+    if step < 0:
         invert = True
         start, stop = stop + 1, start + 1
         step = abs(step)

--- a/rle_array/_algorithms.py
+++ b/rle_array/_algorithms.py
@@ -221,10 +221,10 @@ def find_slice(
 
     if start == 0:
         idx_start = 0
-    elif start >= length:
-        idx_start = len(positions)
     else:
         idx_start = np.searchsorted(positions, start, side="right")
+    # start >= length cannot occur here because NormalizedSlice sets start=0 and stop=0 for empty slices
+
     if stop == 0:
         idx_stop = 0
     elif stop >= length:

--- a/rle_array/_slicing.py
+++ b/rle_array/_slicing.py
@@ -1,0 +1,382 @@
+"""
+Helpers that allows us to deal with Python slicing.
+
+The issue with Python slicing are:
+
+- ``slice`` type:
+  - the types in ``slice`` are completely unchecked (can even be a string or any user-provided type)
+  - the consistency of the values in ``slice`` are unchecked
+  - there is not information about the container size (which makes consistency checks more complicated)
+
+- ``slice.step`` value:
+  - ``step`` has the implicit default 1
+  - there can be forward and backward slices depending on the ``step`` value
+  - there can be step sizes which are not modulo 1
+
+- ``slice.start`` and ``slice.stop`` values:
+  - the implicit defaults of ``start`` and ``stop`` depend on ``step`` (is it positive or negative?)
+  - ``start`` and ``stop`` can be negative (aka "from the end")
+  - ``start`` and ``stop`` can over/underflow the container
+
+We do not want to deal with all these edge cases in every code snipped that deals with slicing, so we introduce
+:class:`NormalizedSlice` that solves the issue in a central place.
+"""
+from typing import Optional
+
+
+class NormalizedSlice:
+    """
+    A normalized slice.
+
+    .. important::
+
+        Do not try to construct this class by hand. Use :func:`NormalizedSlice.from_slice` instead!
+
+    Parameters
+    ----------
+    start
+        First absolute index in the container (inclusive start). Always positive.
+    stop
+        Last absolute index not being part of the slice (exclusive end). Counted from the container start. Can be
+        negative for refersed slices (aka ``step < 0``). Must be normalized so that ``abs(stop - start) % step == 0``.
+        For forward slices (``step > 0``), this must be greater than ``start``. For backward slices (``step < 0``) this
+        must be less than ``start``. For empty slices (``start = stop``), ``start``, ``stop`` and ``step`` have the
+        fixed values 0, 0 and 1.
+    step
+        Step size. Must not be ``0``.
+    container_length
+        Size of the container this slice applies to. Must not be negative. For empty containers
+        (``container_length = 0``), ``start``, ``stop`` and ``step`` have the fixed values 0, 0 and 1.
+    """
+
+    def __init__(self, start: int, stop: int, step: int, container_length: int):
+        if not isinstance(start, int):
+            raise TypeError(f"start must be int but is {type(start).__name__}")
+        if not isinstance(stop, int):
+            raise TypeError(f"stop must be int but is {type(stop).__name__}")
+        if not isinstance(step, int):
+            raise TypeError(f"step must be int but is {type(step).__name__}")
+        if not isinstance(container_length, int):
+            raise TypeError(
+                f"container_length must be int but is {type(container_length).__name__}"
+            )
+
+        self._start = start
+        self._stop = stop
+        self._step = step
+        self._container_length = container_length
+
+        self._verify()
+
+    def _verify(self) -> None:
+        """
+        Verify integrity.
+        """
+        if self.container_length < 0:
+            raise ValueError(
+                f"container_length ({self.container_length}) must be greater or equal to zero"
+            )
+        elif self.container_length == 0:
+            self._verify_container_empty()
+        else:
+            self._verify_container_not_empty()
+
+    def _verify_container_empty(self) -> None:
+        """
+        Verify integrity in case the container is empty (``container_length = 0``).
+        """
+        # empty container => special values required
+        if self.start != 0:
+            raise ValueError(
+                f"for empty containers, start must be 0 but is {self.start}"
+            )
+
+        if self.stop != 0:
+            raise ValueError(f"for empty containers, stop must be 0 but is {self.stop}")
+
+        if self.step != 1:
+            raise ValueError(f"for empty containers, step must be 1 but is {self.step}")
+
+    def _verify_container_not_empty(self) -> None:
+        """
+        Verify integrity in case the container is not empty (``container_length > 0``).
+        """
+        if (self.start < 0) or (self.start >= self.container_length):
+            raise ValueError(
+                f"start ({self.start}) must be in [0,{self.container_length}) but is not"
+            )
+
+        if (self.stop < -abs(self.step)) or (
+            self.stop >= self.container_length + abs(self.step)
+        ):
+            raise ValueError(
+                f"stop ({self.stop}) must be in [{-abs(self.step)},{self.container_length + abs(self.step)}) but is not"
+            )
+
+        if self.start == self.stop:
+            # empty slice
+            if self.start != 0:
+                raise ValueError(
+                    f"for empty slices, start and stop must be 0 but are {self.start}"
+                )
+            if self.step != 1:
+                raise ValueError(f"for empty slices, step must be 1 but is {self.step}")
+        else:
+            # non-empty slice
+            if self.step == 0:
+                raise ValueError("step cannot be zero")
+            elif self.step > 0:
+                # forward slice
+                if self.start > self.stop:
+                    raise ValueError(
+                        "for forward slices, stop must be greater or equal to start"
+                    )
+            else:
+                # backward slice
+                if self.stop > self.start:
+                    raise ValueError(
+                        "for backward slices, start must be greater or equal to stop"
+                    )
+
+            if abs(self.start - self.stop) % abs(self.step) != 0:
+                raise ValueError("start->stop distance is not modulo step")
+
+    @property
+    def start(self) -> int:
+        """
+        Start index of the slice. Inclusive start.
+        """
+        return self._start
+
+    @property
+    def stop(self) -> int:
+        """
+        Stop index of the slice. Exclusive end.
+        """
+        return self._stop
+
+    @property
+    def step(self) -> int:
+        """
+        Step width.
+        """
+        return self._step
+
+    @property
+    def container_length(self) -> int:
+        """
+        Length of the container.
+        """
+        return self._container_length
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(start={self.start}, stop={self.stop}, step={self.step}, container_length="
+            f"{self.container_length})"
+        )
+
+    def __len__(self) -> int:
+        return self._calc_len(start=self.start, stop=self.stop, step=self.step)
+
+    @classmethod
+    def _calc_len(cls, start: int, stop: int, step: int) -> int:
+        """
+        Calculate slice length.
+
+        Parameters
+        ----------
+        start
+            Inclusive start index.
+        stop
+            Exclusive stop index.
+        step
+            Step width.
+        """
+        delta = abs(stop - start)
+        steps = delta // abs(step)
+        if delta % abs(step) != 0:
+            steps += 1
+        return steps
+
+    @classmethod
+    def _check_slice(cls, s: slice) -> None:
+        """
+        Check input slice for convertion.
+        """
+        if not isinstance(s, slice):
+            raise TypeError(f"slice must be a slice but is {type(s).__name__}")
+        if (s.start is not None) and not isinstance(s.start, int):
+            raise TypeError(
+                f"slice start must be int or None but is {type(s.start).__name__}"
+            )
+        if (s.stop is not None) and not isinstance(s.stop, int):
+            raise TypeError(
+                f"slice stop must be int or None but is {type(s.stop).__name__}"
+            )
+        if (s.step is not None) and not isinstance(s.step, int):
+            raise TypeError(
+                f"slice step must be int or None but is {type(s.step).__name__}"
+            )
+        if s.step == 0:
+            raise ValueError("slice step cannot be zero")
+
+    @classmethod
+    def from_slice(cls, container_length: int, s: Optional[slice]) -> "NormalizedSlice":
+        """
+        Create a new :class:`NormalizedSlice` from a given Python ``slice`` and container length.
+
+        Parameters
+        ----------
+        container_length
+            Non-negative container length.
+        s
+            Slice or ``None`` (for "take all").
+
+        Raises
+        ------
+        TypeError: If ``s`` is not ``None`` and not a ``slice`` or any of the arguments for ``slice`` are neither
+                   ``None`` nor an integer.
+        ValueError: Illegal ``slice`` values or ``container_length``.
+        """
+        if s is None:
+            s = slice(None, None, None)
+        cls._check_slice(s)
+
+        if not isinstance(container_length, int):
+            raise TypeError(
+                f"container_length must be an int but is {type(container_length).__name__}"
+            )
+        if container_length < 0:
+            raise ValueError("container_length cannot be negative")
+
+        if container_length == 0:
+            return cls(start=0, stop=0, step=1, container_length=0)
+
+        default_start, default_stop = 0, container_length
+
+        if s.step is not None:
+            step = s.step
+            if step < 0:
+                default_start, default_stop = default_stop - 1, default_start - 1
+        else:
+            step = 1
+
+        def limit(x: int) -> int:
+            a = min(default_start, default_stop)
+            b = max(default_start, default_stop)
+            return max(a, min(b, x))
+
+        if s.start is not None:
+            if s.start < 0:
+                start = limit(container_length + s.start)
+            else:
+                start = limit(s.start)
+        else:
+            start = default_start
+
+        if s.stop is not None:
+            if s.stop < 0:
+                stop = limit(container_length + s.stop)
+            else:
+                stop = limit(s.stop)
+        else:
+            stop = default_stop
+
+        if step > 0:
+            if stop < start:
+                stop = start
+        else:
+            if stop > start:
+                stop = start
+
+        if start == stop:
+            return cls(start=0, stop=0, step=1, container_length=container_length)
+
+        # re-adjusting the range to be modulo `step`
+        stop = start + step * cls._calc_len(start=start, stop=stop, step=step)
+
+        return cls(start=start, stop=stop, step=step, container_length=container_length)
+
+    def project(self, child: "NormalizedSlice") -> "NormalizedSlice":
+        """
+        Project a slice.
+
+        Given a parent slice (``self``) which is applied first, calculate slice of this slice would look like so it can
+        be applied to the original data.
+
+        Parameters
+        ----------
+        child
+            Second slice to apply.
+
+        Raises
+        ------
+        TypeError: If ``child`` is not a ``NormalizedSlice``.
+        ValueError: If ``child.container_length`` is not the length of ``self``.
+
+        Example
+        -------
+        >>> # given some unknown data:
+        >>> data = list(range(100))
+
+        >>> # and two slices:
+        >>> parent = slice(10, -8, 2)
+        >>> child = slice(-20, -1, -1)
+
+        >>> # and the application of both slices
+        >>> expected = data[parent][child]
+
+        >>> # construct a slice that does both steps at once
+        >>> from rle_array._algorithms import NormalizedSlice
+        >>> parent_normalized = NormalizedSlice.from_slice(len(data), parent)
+        >>> child_normalized = NormalizedSlice.from_slice(len(parent), child)
+        >>> projected = parent_normalized.project(child_normalized).to_slice()
+        >>> actual = data[projected]
+        >>> assert actual == expected
+        """
+        if not isinstance(child, NormalizedSlice):
+            raise TypeError(
+                f"child must be NormalizedSlice but is {type(child).__name__}"
+            )
+        if child.container_length != len(self):
+            raise ValueError(
+                f"container_length of child ({child.container_length}) must be length of parent ({len(self)})"
+            )
+
+        start = self.start + child.start * self.step
+        stop = self.start + child.stop * self.step
+        step = self.step * child.step
+
+        return type(self)(
+            start=start, stop=stop, step=step, container_length=self.container_length
+        )
+
+    def to_slice(self) -> Optional[slice]:
+        """
+        Convert :class:`NormalizedSlice` back to a slice.
+
+        Returns ``None`` if no slicing is applied (e.g. the whole container with ``step=1`` is taken).
+        """
+        start: Optional[int] = self.start
+        stop: Optional[int] = self.stop
+        step: Optional[int] = self.step
+
+        if self.step > 0:
+            # forwards
+            if self.start <= 0:
+                start = None
+            if self.stop >= self.container_length:
+                stop = None
+            if self.step == 1:
+                step = None
+        else:
+            # backward
+            if self.start >= self.container_length - 1:
+                start = None
+            if self.stop < 0:
+                stop = None
+
+        if (start is None) and (stop is None) and (step is None):
+            return None
+        else:
+            return slice(start, stop, step)

--- a/rle_array/_slicing.py
+++ b/rle_array/_slicing.py
@@ -141,7 +141,9 @@ class NormalizedSlice:
                     )
 
             if abs(self.start - self.stop) % abs(self.step) != 0:
-                raise ValueError("start->stop distance is not modulo step")
+                raise ValueError(
+                    "The distance between start and stop most be divisible by the step size"
+                )
 
     @property
     def start(self) -> int:
@@ -203,7 +205,7 @@ class NormalizedSlice:
     @classmethod
     def _check_and_prepare_slice(cls, s: Optional[slice]) -> slice:
         """
-        Check and prepare input slice for convertion.
+        Check and prepare input slice for conversion.
         """
         if s is None:
             s = slice(None, None, None)

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -755,9 +755,9 @@ def test_find_single_index_raise(data, positions, i):
             # positions_before
             np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=POSITIONS_DTYPE),
             # s
-            slice(2, 9, -3),
+            slice(9, 2, -3),
             # data_after
-            np.array([9, 6, 3], dtype=np.int8),
+            np.array([10, 7, 4], dtype=np.int8),
             # positions_after
             np.array([1, 2, 3], dtype=POSITIONS_DTYPE),
         ),
@@ -767,9 +767,9 @@ def test_find_single_index_raise(data, positions, i):
             # positions_before
             np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=POSITIONS_DTYPE),
             # s
-            slice(3, 9, -3),
+            slice(9, 3, -3),
             # data_after
-            np.array([9, 6], dtype=np.int8),
+            np.array([10, 7], dtype=np.int8),
             # positions_after
             np.array([1, 2], dtype=POSITIONS_DTYPE),
         ),
@@ -808,6 +808,30 @@ def test_find_single_index_raise(data, positions, i):
             np.array([1], dtype=np.int8),
             # positions_after
             np.array([2], dtype=POSITIONS_DTYPE),
+        ),
+        (
+            # data_before
+            np.array([1, 2, 1, 2], dtype=np.int8),
+            # positions_before
+            np.array([1, 2, 3, 4], dtype=POSITIONS_DTYPE),
+            # s
+            slice(4, 0, 1),
+            # data_after
+            np.array([], dtype=np.int8),
+            # positions_after
+            np.array([], dtype=POSITIONS_DTYPE),
+        ),
+        (
+            # data_before
+            np.array([1, 2, 1, 2], dtype=np.int8),
+            # positions_before
+            np.array([1, 2, 3, 4], dtype=POSITIONS_DTYPE),
+            # s
+            slice(0, 4, -1),
+            # data_after
+            np.array([], dtype=np.int8),
+            # positions_after
+            np.array([], dtype=POSITIONS_DTYPE),
         ),
     ],
 )

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -499,6 +499,30 @@ def test_find_single_index_raise(data, positions, i):
         ),
         (
             # data_before
+            np.array([13, 42], dtype=np.int8),
+            # positions_before
+            np.array([3, 13], dtype=POSITIONS_DTYPE),
+            # s
+            slice(None, None),
+            # data_after
+            np.array([13, 42], dtype=np.int8),
+            # positions_after
+            np.array([3, 13], dtype=POSITIONS_DTYPE),
+        ),
+        (
+            # data_before
+            np.array([42], dtype=np.int8),
+            # positions_before
+            np.array([10], dtype=POSITIONS_DTYPE),
+            # s
+            slice(9, 10),
+            # data_after
+            np.array([42], dtype=np.int8),
+            # positions_after
+            np.array([1], dtype=POSITIONS_DTYPE),
+        ),
+        (
+            # data_before
             np.array([42], dtype=np.int8),
             # positions_before
             np.array([13], dtype=POSITIONS_DTYPE),

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -120,7 +120,10 @@ class TestConstructor:
             NormalizedSlice(start=0, stop=0, step=2, container_length=100)
 
     def test_fail_distance_not_modulo(self):
-        with pytest.raises(ValueError, match="start->stop distance is not modulo step"):
+        with pytest.raises(
+            ValueError,
+            match="The distance between start and stop most be divisible by the step size",
+        ):
             NormalizedSlice(start=0, stop=10, step=3, container_length=100)
 
 

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from rle_array._slicing import NormalizedSlice
@@ -361,15 +362,27 @@ class TestFromSlice:
                 # expected
                 NormalizedSlice(start=0, stop=0, step=1, container_length=10),
             ),
+            (  # numpy.int64
+                # container_length
+                np.int64(100),
+                # s
+                slice(np.int64(0), np.int64(100), np.int64(1)),
+                # expected
+                NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            ),
         ],
     )
     def test_ok(self, container_length, s, expected):
         actual = NormalizedSlice.from_slice(container_length, s)
         assert type(actual) == NormalizedSlice
         assert actual.start == expected.start
+        assert type(actual.start) == int
         assert actual.stop == expected.stop
+        assert type(actual.stop) == int
         assert actual.step == expected.step
+        assert type(actual.step) == int
         assert actual.container_length == expected.container_length
+        assert type(actual.container_length) == int
 
 
 class TestProject:

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -1,0 +1,480 @@
+import pytest
+
+from rle_array._slicing import NormalizedSlice
+
+
+class TestConstructor:
+    def test_ok_simple(self):
+        s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+        assert s.start == 1
+        assert s.stop == 11
+        assert s.step == 2
+        assert s.container_length == 100
+
+    def test_ok_start_at_zero(self):
+        NormalizedSlice(start=0, stop=10, step=2, container_length=100)
+
+    def test_ok_stop_at_modulo_end(self):
+        NormalizedSlice(start=0, stop=12, step=3, container_length=10)
+
+    def test_ok_stop_at_modulo_begin(self):
+        NormalizedSlice(start=0, stop=-3, step=-3, container_length=10)
+
+    def test_ok_zero_length(self):
+        NormalizedSlice(start=0, stop=0, step=1, container_length=0)
+
+    def test_fail_start_none(self):
+        with pytest.raises(TypeError, match="start must be int but is None"):
+            NormalizedSlice(start=None, stop=10, step=2, container_length=100)
+
+    def test_fail_stop_none(self):
+        with pytest.raises(TypeError, match="stop must be int but is None"):
+            NormalizedSlice(start=1, stop=None, step=2, container_length=100)
+
+    def test_fail_step_none(self):
+        with pytest.raises(TypeError, match="step must be int but is None"):
+            NormalizedSlice(start=1, stop=10, step=None, container_length=100)
+
+    def test_fail_container_length_none(self):
+        with pytest.raises(TypeError, match="container_length must be int but is None"):
+            NormalizedSlice(start=1, stop=10, step=2, container_length=None)
+
+    def test_fail_step_zero(self):
+        with pytest.raises(ValueError, match="step cannot be zero"):
+            NormalizedSlice(start=1, stop=10, step=0, container_length=100)
+
+    def test_fail_start_negative(self):
+        with pytest.raises(
+            ValueError, match=r"start \(-1\) must be in \[0,100\) but is not"
+        ):
+            NormalizedSlice(start=-1, stop=10, step=1, container_length=100)
+
+    def test_fail_start_large(self):
+        with pytest.raises(
+            ValueError, match=r"start \(100\) must be in \[0,100\) but is not"
+        ):
+            NormalizedSlice(start=100, stop=10, step=1, container_length=100)
+
+    def test_fail_stop_small(self):
+        with pytest.raises(
+            ValueError, match=r"stop \(-2\) must be in \[-1,101\) but is not"
+        ):
+            NormalizedSlice(start=2, stop=-2, step=-1, container_length=100)
+
+    def test_fail_stop_large(self):
+        with pytest.raises(
+            ValueError, match=r"stop \(102\) must be in \[-1,101\) but is not"
+        ):
+            NormalizedSlice(start=2, stop=102, step=1, container_length=100)
+
+    def test_fail_container_length_negative(self):
+        with pytest.raises(
+            ValueError,
+            match=r"container_length \(-1\) must be greater or equal to zero",
+        ):
+            NormalizedSlice(start=2, stop=102, step=1, container_length=-1)
+
+    def test_fail_container_empty_start_fail(self):
+        with pytest.raises(
+            ValueError, match="for empty containers, start must be 0 but is 1"
+        ):
+            NormalizedSlice(start=1, stop=0, step=1, container_length=0)
+
+    def test_fail_container_empty_stop_fail(self):
+        with pytest.raises(
+            ValueError, match="for empty containers, stop must be 0 but is 1"
+        ):
+            NormalizedSlice(start=0, stop=1, step=1, container_length=0)
+
+    def test_fail_container_empty_step_fail(self):
+        with pytest.raises(
+            ValueError, match="for empty containers, step must be 1 but is 2"
+        ):
+            NormalizedSlice(start=0, stop=0, step=2, container_length=0)
+
+    def test_fail_forward_slice_not_forward(self):
+        with pytest.raises(
+            ValueError,
+            match="for forward slices, stop must be greater or equal to start",
+        ):
+            NormalizedSlice(start=1, stop=0, step=1, container_length=100)
+
+    def test_fail_backward_slice_not_backward(self):
+        with pytest.raises(
+            ValueError,
+            match="for backward slices, start must be greater or equal to stop",
+        ):
+            NormalizedSlice(start=0, stop=1, step=-1, container_length=100)
+
+    def test_fail_slice_empty_start(self):
+        with pytest.raises(
+            ValueError, match="for empty slices, start and stop must be 0 but are 1"
+        ):
+            NormalizedSlice(start=1, stop=1, step=1, container_length=100)
+
+    def test_fail_slice_empty_step(self):
+        with pytest.raises(
+            ValueError, match="for empty slices, step must be 1 but is 2"
+        ):
+            NormalizedSlice(start=0, stop=0, step=2, container_length=100)
+
+    def test_fail_distance_not_modulo(self):
+        with pytest.raises(ValueError, match="start->stop distance is not modulo step"):
+            NormalizedSlice(start=0, stop=10, step=3, container_length=100)
+
+
+class TestFrozen:
+    def test_start(self):
+        s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            s.start = 2
+
+    def test_stop(self):
+        s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            s.stop = 2
+
+    def test_step(self):
+        s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            s.step = 3
+
+    def test_container_length(self):
+        s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            s.container_length = 3
+
+
+def test_repr():
+    s = NormalizedSlice(start=1, stop=11, step=2, container_length=100)
+    assert repr(s) == "NormalizedSlice(start=1, stop=11, step=2, container_length=100)"
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        (  # empty
+            # s
+            NormalizedSlice(start=0, stop=0, step=1, container_length=0),
+            # expected
+            0,
+        ),
+        (  # simple, forward
+            # s
+            NormalizedSlice(start=0, stop=10, step=1, container_length=100),
+            # expected
+            10,
+        ),
+        (  # simple, backward
+            # s
+            NormalizedSlice(start=9, stop=-1, step=-1, container_length=100),
+            # expected
+            10,
+        ),
+        (  # even, forward
+            # s
+            NormalizedSlice(start=0, stop=10, step=2, container_length=100),
+            # expected
+            5,
+        ),
+        (  # even, backward
+            # s
+            NormalizedSlice(start=9, stop=-1, step=-2, container_length=100),
+            # expected
+            5,
+        ),
+        (  # complex, forward
+            # s
+            NormalizedSlice(start=10, stop=22, step=3, container_length=100),
+            # expected
+            4,
+        ),
+        (  # complex, backward
+            # s
+            NormalizedSlice(start=19, stop=7, step=-3, container_length=100),
+            # expected
+            4,
+        ),
+    ],
+)
+def test_len(s, expected):
+    assert len(s) == expected
+
+
+class TestFromSlice:
+    def test_fail_slice_wrong_type(self):
+        with pytest.raises(TypeError, match="slice must be a slice but is str"):
+            NormalizedSlice.from_slice(container_length=10, s="foo")
+
+    def test_fail_slice_start_wrong_type(self):
+        with pytest.raises(
+            TypeError, match="slice start must be int or None but is str"
+        ):
+            NormalizedSlice.from_slice(container_length=10, s=slice("foo", 20, 2))
+
+    def test_fail_slice_stop_wrong_type(self):
+        with pytest.raises(
+            TypeError, match="slice stop must be int or None but is str"
+        ):
+            NormalizedSlice.from_slice(container_length=10, s=slice(2, "foo", 2))
+
+    def test_fail_slice_step_wrong_type(self):
+        with pytest.raises(
+            TypeError, match="slice step must be int or None but is str"
+        ):
+            NormalizedSlice.from_slice(container_length=10, s=slice(2, 20, "foo"))
+
+    def test_fail_step_zero(self):
+        with pytest.raises(ValueError, match="slice step cannot be zero"):
+            NormalizedSlice.from_slice(container_length=10, s=slice(2, 10, 0))
+
+    def test_fail_container_length_wrong_type(self):
+        with pytest.raises(
+            TypeError, match="container_length must be an int but is str"
+        ):
+            NormalizedSlice.from_slice(container_length="foo", s=slice(2, 10, 2))
+
+    def test_fail_container_length_negative(self):
+        with pytest.raises(ValueError, match="container_length cannot be negative"):
+            NormalizedSlice.from_slice(container_length=-1, s=slice(2, 10, 2))
+
+    @pytest.mark.parametrize(
+        "container_length, s, expected",
+        [
+            (  # empty
+                # container_length
+                0,
+                # s
+                None,
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=0),
+            ),
+            (  # implicit full via None
+                # container_length
+                100,
+                # s
+                None,
+                # expected
+                NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            ),
+            (  # explicit full via slice
+                # container_length
+                100,
+                # s
+                slice(None, None, None),
+                # expected
+                NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            ),
+            (  # explicit full
+                # container_length
+                100,
+                # s
+                slice(0, 100, 1),
+                # expected
+                NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            ),
+            (  # full reverse
+                # container_length
+                100,
+                # s
+                slice(None, None, -1),
+                # expected
+                NormalizedSlice(start=99, stop=-1, step=-1, container_length=100),
+            ),
+            (  # start negative
+                # container_length
+                100,
+                # s
+                slice(-20, None, None),
+                # expected
+                NormalizedSlice(start=80, stop=100, step=1, container_length=100),
+            ),
+            (  # start negative overflow container
+                # container_length
+                100,
+                # s
+                slice(-1000, None, None),
+                # expected
+                NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            ),
+            (  # stop negative
+                # container_length
+                100,
+                # s
+                slice(None, -20, None),
+                # expected
+                NormalizedSlice(start=0, stop=80, step=1, container_length=100),
+            ),
+            (  # stop negative overflow container
+                # container_length
+                100,
+                # s
+                slice(None, -1000, None),
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=100),
+            ),
+            (  # stop negative overflow start
+                # container_length
+                100,
+                # s
+                slice(10, -1000, None),
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=100),
+            ),
+            (  # stop negative overflow start reverse
+                # container_length
+                100,
+                # s
+                slice(10, -10, -1),
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=100),
+            ),
+            (  # modulo normlization forward
+                # container_length
+                10,
+                # s
+                slice(0, 10, 3),
+                # expected
+                NormalizedSlice(start=0, stop=12, step=3, container_length=10),
+            ),
+            (  # modulo normlization forward, empty
+                # container_length
+                10,
+                # s
+                slice(0, 0, 3),
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=10),
+            ),
+            (  # modulo normlization backward
+                # container_length
+                10,
+                # s
+                slice(0, -1000, -3),
+                # expected
+                NormalizedSlice(start=0, stop=-3, step=-3, container_length=10),
+            ),
+            (  # modulo normlization backward, empty
+                # container_length
+                10,
+                # s
+                slice(0, 0, -3),
+                # expected
+                NormalizedSlice(start=0, stop=0, step=1, container_length=10),
+            ),
+        ],
+    )
+    def test_ok(self, container_length, s, expected):
+        actual = NormalizedSlice.from_slice(container_length, s)
+        assert type(actual) == NormalizedSlice
+        assert actual.start == expected.start
+        assert actual.stop == expected.stop
+        assert actual.step == expected.step
+        assert actual.container_length == expected.container_length
+
+
+class TestProject:
+    def test_fail_no_normalizedslice(self):
+        s1 = NormalizedSlice(start=0, stop=10, step=1, container_length=100)
+        s2 = slice(1, 2, 1)
+        with pytest.raises(
+            TypeError, match="child must be NormalizedSlice but is slice"
+        ):
+            s1.project(s2)
+
+    def test_fail_len_diff(self):
+        s1 = NormalizedSlice(start=0, stop=10, step=1, container_length=100)
+        s2 = NormalizedSlice(start=0, stop=10, step=1, container_length=20)
+        with pytest.raises(
+            ValueError,
+            match=r"container_length of child \(20\) must be length of parent \(10\)",
+        ):
+            s1.project(s2)
+
+    @pytest.mark.parametrize(
+        "s1, s2, expected",
+        [
+            (  # simple full take
+                # s1
+                NormalizedSlice(start=0, stop=10, step=1, container_length=100),
+                # s2
+                NormalizedSlice(start=0, stop=10, step=1, container_length=10),
+                # expected
+                NormalizedSlice(start=0, stop=10, step=1, container_length=100),
+            ),
+            (  # reverse reverse
+                # s1
+                NormalizedSlice(start=9, stop=-1, step=-1, container_length=100),
+                # s2
+                NormalizedSlice(start=9, stop=-1, step=-1, container_length=10),
+                # expected
+                NormalizedSlice(start=0, stop=10, step=1, container_length=100),
+            ),
+            (  # two modulos
+                # s1
+                NormalizedSlice(start=2, stop=29, step=3, container_length=100),
+                # s2
+                NormalizedSlice(start=1, stop=7, step=3, container_length=9),
+                # expected
+                NormalizedSlice(start=5, stop=23, step=9, container_length=100),
+            ),
+        ],
+    )
+    def test_ok(self, s1, s2, expected):
+        actual = s1.project(s2)
+        assert type(actual) == NormalizedSlice
+        assert actual.start == expected.start
+        assert actual.stop == expected.stop
+        assert actual.step == expected.step
+        assert actual.container_length == expected.container_length
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        (  # full take
+            # s
+            NormalizedSlice(start=0, stop=100, step=1, container_length=100),
+            # expected
+            None,
+        ),
+        (  # full reverse
+            # s
+            NormalizedSlice(start=99, stop=-1, step=-1, container_length=100),
+            # expected
+            slice(None, None, -1),
+        ),
+        (  # only start
+            # s
+            NormalizedSlice(start=1, stop=100, step=1, container_length=100),
+            # expected
+            slice(1, None, None),
+        ),
+        (  # only stop
+            # s
+            NormalizedSlice(start=0, stop=99, step=1, container_length=100),
+            # expected
+            slice(None, 99, None),
+        ),
+        (  # only step
+            # s
+            NormalizedSlice(start=0, stop=100, step=2, container_length=100),
+            # expected
+            slice(None, None, 2),
+        ),
+        (  # complex
+            # s
+            NormalizedSlice(start=1, stop=22, step=3, container_length=100),
+            # expected
+            slice(1, 22, 3),
+        ),
+    ],
+)
+def test_to_slice(s, expected):
+    actual = s.to_slice()
+    if expected is None:
+        assert actual is None
+    else:
+        assert type(actual) == slice
+        assert actual.start == expected.start
+        assert actual.stop == expected.stop
+        assert actual.step == expected.step


### PR DESCRIPTION
The slicing infrastructure also provides features that are currently unused (projection + convertion back to slices). This is required for the upcoming proper implementation of views (we're currently mocking views in a broken way and the upcoming pandas 1.0 release demands extension arrays to do this correctly). I have the views nearly ready locally but wanted to keep the PRs reviewable.