### PR TITLE
Migrate to pandas 1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 python = ">=3.6.1,<3.9"
 numba = ">=0.45"
 numpy = ">=1.17"
-pandas = ">=1.0.3,<1.1"
+pandas = ">=1.1,<1.2"
 
 [tool.poetry.dev-dependencies]
 asv = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ sphinx = "*"
 
 [tool.pytest.ini_options]
 addopts = "--cov=rle_array --cov-report term-missing --cov-report xml"
-testpath = "tests"
+testpaths = "tests"

--- a/rle_array/array.py
+++ b/rle_array/array.py
@@ -85,12 +85,6 @@ class _ViewAnchor:
     def __init__(self, array: "RLEArray") -> None:
         self.array = ref(array)
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, _ViewAnchor):
-            return id(self.array) == id(other.array)
-        else:
-            return False
-
     def __hash__(self) -> int:
         return id(self.array)
 

--- a/rle_array/array.py
+++ b/rle_array/array.py
@@ -79,7 +79,7 @@ def _normalize_arraylike_indexing(arr: Any, length: int) -> np.ndarray:
 
 class _ViewAnchor:
     """
-    Anchor object that references an RLEArray because it is not hashable.
+    Anchor object that references a RLEArray because it is not hashable.
     """
 
     def __init__(self, array: "RLEArray") -> None:

--- a/rle_array/dtype.py
+++ b/rle_array/dtype.py
@@ -30,6 +30,11 @@ class RLEDtype(ExtensionDtype):
         """
         Strict construction from a string, raise a TypeError if not possible.
         """
+        if not isinstance(string, str):
+            raise TypeError(
+                f"'construct_from_string' expects a string, got {type(string)}"
+            )
+
         prefix = "RLEDtype["
         suffix = "]"
         if not (string.startswith(prefix) and string.endswith(suffix)):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -250,16 +250,10 @@ def test_unary_operator(
     uncompressed_series: pd.Series,
     unary_operator: FUnaryOperator,
 ) -> None:
-    if unary_operator in (operator.neg, operator.pos):
-        # series implementation seems to cast the rle-array to numpy
-        dtype = float
-    else:
-        dtype = RLEDtype(float)
-
     actual = unary_operator(rle_series)
-    assert actual.dtype == dtype
+    assert actual.dtype == RLEDtype(float)
 
-    expected = unary_operator(uncompressed_series).astype(dtype)
+    expected = unary_operator(uncompressed_series).astype(RLEDtype(float))
     pd.testing.assert_series_equal(actual, expected)
 
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -290,6 +290,15 @@ def use_numpy(request: SubRequest) -> bool:
     return b
 
 
+@pytest.fixture(params=[None, lambda x: x])
+def sort_by_key(request: SubRequest) -> Any:
+    """
+    Simple fixture for testing keys in sorting methods.
+    Tests None (no key) and the identity key.
+    """
+    return request.param
+
+
 class TestArithmeticOps(base.BaseArithmeticOpsTests):
     frame_scalar_exc = None
     series_array_exc = None
@@ -358,8 +367,7 @@ class TestPrinting(base.BasePrintingTests):
 
 
 class TestReshaping(base.BaseReshapingTests):
-    def test_concat_mixed_dtypes(self) -> None:
-        pytest.skip("upstream test is broken?")
+    pass
 
 
 class TestSetitem(base.BaseSetitemTests):

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -148,10 +148,15 @@ def test_array_numpy(data_orig: pd.Series, data_rle: pd.Series, numpy_op: str) -
     f = getattr(np, numpy_op)
     result_orig = f(data_orig.array)
     result_rle = f(data_rle.array)
-    assert (np.isnan(result_orig) and np.isnan(result_rle)) or (
-        result_orig == result_rle
-    )
-    assert type(result_orig) == type(result_rle)
+    assert (pd.isna(result_orig) and pd.isna(result_rle)) or (result_orig == result_rle)
+    if len(data_orig) > 0:
+        assert type(result_orig) == type(result_rle)
+    else:
+        # pandas might use pd.NA, while we still use float, see https://github.com/pandas-dev/pandas/issues/35475
+        if isinstance(result_orig, type(pd.NA)):
+            assert type(result_rle) == float
+        else:
+            assert type(result_orig) == type(result_rle)
 
 
 def test_array_numpy_axis_notimplemented(data_rle: pd.Series, numpy_op: str) -> None:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,3 +1,5 @@
+import gc
+
 import numpy as np
 import pytest
 from numpy import testing as npt
@@ -108,3 +110,18 @@ def test_slicing() -> None:
 
     for arr_np, arr_rle in zip(arrays_np, arrays_rle):
         npt.assert_array_equal(arr_np, arr_rle)
+
+
+def test_anchor_ref() -> None:
+    try:
+        gc.disable()
+        gc.collect()
+
+        n_objects_pre = len([o for o in gc.get_objects() if isinstance(o, RLEArray)])
+
+        RLEArray._from_sequence(np.arange(10))
+
+        n_objects_post = len([o for o in gc.get_objects() if isinstance(o, RLEArray)])
+        assert n_objects_pre == n_objects_post
+    finally:
+        gc.enable()

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy import testing as npt
 
-from rle_array import RLEArray
+from rle_array.array import RLEArray, _ViewAnchor
 
 pytestmark = pytest.mark.filterwarnings("ignore:performance")
 
@@ -117,11 +117,15 @@ def test_anchor_ref() -> None:
         gc.disable()
         gc.collect()
 
-        n_objects_pre = len([o for o in gc.get_objects() if isinstance(o, RLEArray)])
+        n_objects_pre = len(
+            [o for o in gc.get_objects() if isinstance(o, (RLEArray, _ViewAnchor))]
+        )
 
         RLEArray._from_sequence(np.arange(10))
 
-        n_objects_post = len([o for o in gc.get_objects() if isinstance(o, RLEArray)])
+        n_objects_post = len(
+            [o for o in gc.get_objects() if isinstance(o, (RLEArray, _ViewAnchor))]
+        )
         assert n_objects_pre == n_objects_post
     finally:
         gc.enable()


### PR DESCRIPTION
- `hash(rle_array)` is not supposed to work anymore. So our view
  tracking code needs to deal with this and now uses a weakref-anchor to
  put arrays into `WeakSet`
- `RLEArray.astype(str)` now works as intended
- `RLEDtype.construct_from_string` now checks that parameter is a string
- Unary operators on RLEArray now always return RLEDtype values
- Upstream `series.array.fillna` can now return a `PandasArray` instead
  of a NumPy ndarray
- Some more tests (requires new fixture)
- `PandasArray.{min,max}` can return NA (instead of NaN) for empty
  arrays